### PR TITLE
Added service discovery function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,99 @@
-![build-status](https://travis-ci.com/theonestack/hl-component-ecs.svg?branch=master)
+# aurora (MySQL) CfHighlander component
+## Parameters
 
-### Cfhighlander aurora 2 mysql component
+| Name | Use | Default | Global | Type | Allowed Values |
+| ---- | --- | ------- | ------ | ---- | -------------- |
+| EnvironmentName | Tagging | dev | true | string
+| EnvironmentType | Tagging | development | true | string | ['development','production']
+| VPCId | Security Groups | None | false | AWS::EC2::VPC::Id
+| DnsDomain | DNS domain to use | None | true | string
+| SubnetIds | List of subnets | None | false | CommaDelimitedList
+| KmsKeyId | KMS ID | None | false | string (arn)
+| NamespaceId | Service discovery namespace ID | None | false | string
+| SnapshotId | Snapshot ID to provision from | None | false | string
+| WriterInstanceType | Writer instance type *if engine is set to provisioned* | None | false | string
+| ReaderInstanceType | Reader instance type *if engine is set to provisioned* | None | false | string
+| AutoPause | Whether to auto-pause *if engine is set to serverless* | true | false | bool
+| MaxCapacity | Maximum serverless instances *if engine is set to serverless* | 2 | false | int
+| MinCapacity | Minimum serverless instances *if engine is set to serverless* | 2 | false | int
+| SecondsUntilAutoPause | Seconds until autopause *if engine is set to serverless* | 3600 (1 hour) | false | int
 
-**Engine:** MySQL 5.7
+## Outputs/Exports
 
-```bash
+| Name | Value | Exported |
+| ---- | ----- | -------- |
+| SecretCredentials | Secret password if set to auto generate | true
+| SecurityGroup | Security Group name | true
+| ServiceRegistry | CloudMap service registry ID | true
+| DBClusterId | Database Cluster ID | true
 
-# install highlander gem
-$ gem install cfhighlander
+## Included Components
 
-# build and validate standalone component
-$ cfhighlander cfcompile --validate aurora2-mysql
+[lib-ec2](https://github.com/theonestack/hl-component-lib-ec2)
 
+## Example Configuration
+### Highlander
+  Component name:'database', template: 'aurora-mysql' do
+    parameter name: 'DnsDomain', value: root_domain
+    parameter name: 'DnsFormat', value: FnSub("${EnvironmentName}.#{root_domain}")
+    parameter name: 'SubnetIds', value: cfout('vpcv2', 'PersistenceSubnets')
+    parameter name: 'WriterInstanceType', value: writer_instance
+    parameter name: 'ReaderInstanceType', value: reader_instance
+    parameter name: 'EnableReader', value: 'true'
+    parameter name: 'StackOctet', value: '80'
+    parameter name: 'NamespaceId', value: cfout('servicediscovery', 'NamespaceId')
+  end
+
+### Aurora MySQL Configuration
+```
+hostname: db
+db_name: appdb
+dns_format: ${DnsFormat}
+
+storage_encrypted: true
+engine: aurora-mysql
+engine_version: '5.7.mysql_aurora.2.09.2'
+
+writer_instance: db.r3.large
+reader_instance: db.r3.large
+
+deletion_policy: Snapshot
+
+secret_username: appuser
+
+security_group:
+  -
+    rules:
+      -
+        IpProtocol: tcp
+        FromPort: 3306
+        ToPort: 3306
+    ips:
+      - stack
+      - company_office
+      - company_client_vpn
+
+service_discovery:
+  name: db
 ```
 
+## Cfhighlander Setup
 
-### Parameters
+install cfhighlander [gem](https://github.com/theonestack/cfhighlander)
 
-TBD
+```bash
+gem install cfhighlander
+```
 
-### Configuration options
+or via docker
 
-TBD
+```bash
+docker pull theonestack/cfhighlander
+```
+## Testing Components
 
-### Outputs
+Running the tests
 
-TBD
+```bash
+cfhighlander cftest aurora2-mysql
+```

--- a/README.md
+++ b/README.md
@@ -97,5 +97,5 @@ docker pull theonestack/cfhighlander
 Running the tests
 
 ```bash
-cfhighlander cftest aurora2-mysql
+cfhighlander cftest aurora-mysql
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 ## Example Configuration
 ### Highlander
+```
   Component name:'database', template: 'aurora-mysql' do
     parameter name: 'DnsDomain', value: root_domain
     parameter name: 'DnsFormat', value: FnSub("${EnvironmentName}.#{root_domain}")
@@ -43,6 +44,7 @@
     parameter name: 'StackOctet', value: '80'
     parameter name: 'NamespaceId', value: cfout('servicediscovery', 'NamespaceId')
   end
+```
 
 ### Aurora MySQL Configuration
 ```

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -29,5 +29,7 @@ CfhighlanderTemplate do
 
     ComponentParam 'EnablePerformanceInsights', defined?(performance_insights) ? performance_insights : false
     ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7
+
+    ComponentParam 'NamespaceId' if defined? service_discovery
   end
 end

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -1,5 +1,5 @@
 CfhighlanderTemplate do
-  Name 'aurora-mysq'
+  Name 'aurora-mysql'
   DependsOn 'vpc'
 
   Parameters do

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -183,4 +183,9 @@ CloudFormation do
     }
   end
 
+  Output(:DBClusterId) {
+    Value(Ref(:DBCluster))
+    Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-dbcluster-id")
+  }
+
 end

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -149,6 +149,38 @@ CloudFormation do
     ResourceRecords [ FnGetAtt('DBCluster','Endpoint.Address') ]
   }
 
+  registry = {}
+  service_discovery = external_parameters.fetch(:service_discovery, {})
 
+  unless service_discovery.empty?
+    ServiceDiscovery_Service(:ServiceRegistry) {
+      NamespaceId Ref(:NamespaceId)
+      Name service_discovery['name']  if service_discovery.has_key? 'name'
+      DnsConfig({
+        DnsRecords: [{
+          TTL: 60,
+          Type: 'CNAME'
+        }],
+        RoutingPolicy: 'WEIGHTED'
+      })
+      if service_discovery.has_key? 'healthcheck'
+        HealthCheckConfig service_discovery['healthcheck']
+      else
+        HealthCheckCustomConfig ({ FailureThreshold: (service_discovery['failure_threshold'] || 1) })
+      end
+    }
+
+    ServiceDiscovery_Instance(:RegisterInstance) {
+      InstanceAttributes(
+        AWS_INSTANCE_CNAME: FnGetAtt('DBCluster','Endpoint.Address')
+      )
+      ServiceId Ref(:ServiceRegistry)
+    }
+
+    Output(:ServiceRegistry) {
+      Value(Ref(:ServiceRegistry))
+      Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-CloudMapService")
+    }
+  end
 
 end

--- a/tests/service_registry.test.yaml
+++ b/tests/service_registry.test.yaml
@@ -1,0 +1,7 @@
+test_metadata:
+  type: config
+  name: enable service registry
+  description: If you specify service_registry in the config, it should then expect the namespace component paremeter, and add service_discovery['name'] as the record
+
+service_discovery:
+  name: db


### PR DESCRIPTION
A customer of ours needed their DB to be accessible via their internal AWS Cloud Map namespace (using "db"), and setting the DNS zone to "dev.local" (their namespace) gave an error because the Route53 component can't edit AWS Cloud Map zones.

I (mostly) just copied the way ECS-Services add themselves to Service Registry, except in this case it just points to the CNAME that RDS creates.