### PR TITLE
Fix to migration 3.4.4 to newer (absent EngineMode enforce the Cluste…

### DIFF
--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -34,7 +34,7 @@ CfhighlanderTemplate do
 
     ComponentParam 'NamespaceId' if defined? service_discovery
 
-    ComponentParam 'EnableReplicaAutoScaling', 'false', isGlobal: true
+    ComponentParam 'EnableReplicaAutoScaling', 'false'
 
     ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : ''
   end

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -35,5 +35,7 @@ CfhighlanderTemplate do
     ComponentParam 'NamespaceId' if defined? service_discovery
 
     ComponentParam 'EnableReplicaAutoScaling', 'false', isGlobal: true
+
+    ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : '', isGlobal: true
   end
 end

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -36,6 +36,6 @@ CfhighlanderTemplate do
 
     ComponentParam 'EnableReplicaAutoScaling', 'false', isGlobal: true
 
-    ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : '', isGlobal: true
+    ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : ''
   end
 end


### PR DESCRIPTION
Fix to migration v3.4.4 to newer (absent EngineMode enforce the Cluster v3.4.4 deletions!), forwarding to CloudWatch was not implemented.