### PR TITLE
8 fixes there

### DIFF
--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -17,6 +17,7 @@ CfhighlanderTemplate do
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     ComponentParam 'EnableReader', 'false'
     ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
+    ComponentParam 'ReaderPromotionTier', 1, allowedValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -14,19 +14,18 @@ CfhighlanderTemplate do
     ComponentParam 'ScalableTargetMaxCapacity'
     ComponentParam 'EngineVersion'
     ComponentParam 'StorageEncrypted', false
-    
+    ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
+
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
       ComponentParam 'ReaderInstanceType'
       ComponentParam 'EnableReader', 'false'
-      ComponentParam 'StorageType', 'io1', allowedValues: ['io1', 'io2', 'gp3']
     end
 
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
       ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
-      ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     end
 
     ComponentParam 'KmsKeyId' if defined? kms_key_id

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -12,6 +12,7 @@ CfhighlanderTemplate do
     ComponentParam 'SnapshotID'
     ComponentParam 'ScalableTargetMinCapacity'
     ComponentParam 'ScalableTargetMaxCapacity'
+    ComponentParam 'EngineVersion', ''
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
@@ -19,9 +20,9 @@ CfhighlanderTemplate do
       ComponentParam 'EnableReader', 'false'
     end
 
-    if engine_mode == 'serverless'
-      ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
-      ComponentParam 'MinCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
+    if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
+      ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
+      ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     end
 

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -18,6 +18,7 @@ CfhighlanderTemplate do
     ComponentParam 'EnableReader', 'false'
     ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     ComponentParam 'ReaderPromotionTier', 1, allowedValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+    ComponentParam 'DatabaseInsightsMode', 'standard', allowedValues: ['standard', 'advanced']
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
@@ -33,7 +34,8 @@ CfhighlanderTemplate do
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
     ComponentParam 'EnablePerformanceInsights', defined?(performance_insights) ? performance_insights : false
-    ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7
+    ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7,
+                    allowedValues: [7, 31, 62, 93, 124, 155, 186, 217, 248, 279, 310, 341, 372, 403, 434, 465, 496, 527, 558, 589, 620, 651, 682, 713, 731]
     ComponentParam 'NamespaceId' if defined? service_discovery
     ComponentParam 'EnableReplicaAutoScaling', 'false'
     ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : ''

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -16,6 +16,7 @@ CfhighlanderTemplate do
     ComponentParam 'StorageEncrypted', false
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     ComponentParam 'EnableReader', 'false'
+    ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
@@ -25,7 +26,6 @@ CfhighlanderTemplate do
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
       ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
-      ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     end
 
     ComponentParam 'KmsKeyId' if defined? kms_key_id

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -13,7 +13,8 @@ CfhighlanderTemplate do
     ComponentParam 'ScalableTargetMinCapacity'
     ComponentParam 'ScalableTargetMaxCapacity'
     ComponentParam 'EngineVersion'
-
+    ComponentParam 'StorageEncrypted', false
+    
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
       ComponentParam 'ReaderInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -12,7 +12,7 @@ CfhighlanderTemplate do
     ComponentParam 'SnapshotID'
     ComponentParam 'ScalableTargetMinCapacity'
     ComponentParam 'ScalableTargetMaxCapacity'
-    ComponentParam 'EngineVersion', ''
+    ComponentParam 'EngineVersion'
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -15,11 +15,11 @@ CfhighlanderTemplate do
     ComponentParam 'EngineVersion'
     ComponentParam 'StorageEncrypted', false
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
+    ComponentParam 'EnableReader', 'false'
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
-      ComponentParam 'ReaderInstanceType'
-      ComponentParam 'EnableReader', 'false'
+      ComponentParam 'ReaderInstanceType'      
     end
 
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -19,27 +19,24 @@ CfhighlanderTemplate do
       ComponentParam 'WriterInstanceType'
       ComponentParam 'ReaderInstanceType'
       ComponentParam 'EnableReader', 'false'
+      ComponentParam 'StorageType', 'io1', allowedValues: ['io1', 'io2', 'gp3']
     end
 
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
       ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
+      ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     end
 
     ComponentParam 'KmsKeyId' if defined? kms_key_id
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
-
     ComponentParam 'EnablePerformanceInsights', defined?(performance_insights) ? performance_insights : false
     ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7
-
     ComponentParam 'NamespaceId' if defined? service_discovery
-
     ComponentParam 'EnableReplicaAutoScaling', 'false'
-
     ComponentParam 'EnableCloudwatchLogsExports', defined?(log_exports) ? log_exports : ''
-
     ComponentParam 'EnableLocalWriteForwarding', 'false'
   end
 end

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -8,6 +8,8 @@ CloudFormation do
   Condition("UseSnapshotID", FnNot(FnEquals(Ref(:SnapshotID), '')))
   Condition("EnablePerformanceInsights", FnEquals(Ref(:EnablePerformanceInsights), 'true'))
 
+  # This is not in terms of Serverless V2 ACU but in terms of AutoScaling instances with TargetTracking policies.
+  # I.e. when you get the number of replicas more than one. Who knows - sometimes it makes sense.
   # Scale-in still does not work for Serverless. Only Scale-out does.
   Condition("EnableReplicaAutoScaling", FnAnd([FnEquals(Ref(:EnableReplicaAutoScaling), 'true'), FnEquals(Ref(:EnableReader), 'true')]))
   

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -279,8 +279,8 @@ CloudFormation do
   ApplicationAutoScaling_ScalableTarget(:ServiceScalingTarget) do
     DependsOn 'RDSReplicaAutoScaleRole'
     Condition 'EnableReplicaAutoScaling'
-    MaxCapacity FnJoin('', ['0', Ref(:ScalableTargetMaxCapacity)]) # Ref makes a String. The lead zero does the trick: CloudFormation parse it as Number.
-    MinCapacity FnJoin('', ['0', Ref(:ScalableTargetMinCapacity)]) # Ref makes a String. The lead zero does the trick: CloudFormation parse it as Number.
+    MaxCapacity FnJoin('', ['0', Ref(:ScalableTargetMaxCapacity)]) # Ref makes a String. The lead zero does the trick: CloudFormation parses it as a Number.
+    MinCapacity FnJoin('', ['0', Ref(:ScalableTargetMinCapacity)]) # Ref makes a String. The lead zero does the trick: CloudFormation parses it as a Number.
     ResourceId FnJoin(':',["cluster",Ref(:DBCluster)])
     RoleARN FnGetAtt(:RDSReplicaAutoScaleRole,:Arn)
     ScalableDimension "rds:cluster:ReadReplicaCount"

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -84,6 +84,7 @@ CloudFormation do
   engine_version = external_parameters.fetch(:engine_version, nil)
   engine_mode = external_parameters.fetch(:engine_mode, nil)
   maintenance_window = external_parameters.fetch(:maintenance_window, nil)
+  backtrack_window = external_parameters.fetch(:backtrack_window, nil)
 
   RDS_DBCluster(:DBCluster) {
     Engine external_parameters[:engine]
@@ -107,6 +108,11 @@ CloudFormation do
     PerformanceInsightsRetentionPeriod  FnIf('EnablePerformanceInsights',
                                               FnIf('EnableDatabaseInsightsAdvanced', 465, Ref('PerformanceInsightsRetentionPeriod')),
                                               Ref('AWS::NoValue'))
+    
+    # Basically the same as `BacktrackWindow = 0`
+    if ((not backtrack_window.nil?) and (backtrack_window != 0))
+      BacktrackWindow backtrack_window
+    end
 
     DatabaseName db_name if !db_name.empty?
     DBClusterParameterGroupName Ref(:DBClusterParameterGroup)

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -134,6 +134,7 @@ CloudFormation do
       Engine external_parameters[:engine]
       DBInstanceClass 'db.serverless'
       DBClusterIdentifier Ref(:DBCluster)
+      PromotionTier FnJoin('', ['0', Ref(:ReaderPromotionTier)])
       Tags tags
     }
   else
@@ -166,6 +167,7 @@ CloudFormation do
       DBInstanceClass Ref(:ReaderInstanceType)
       EnablePerformanceInsights Ref('EnablePerformanceInsights')
       PerformanceInsightsRetentionPeriod FnIf('EnablePerformanceInsights', Ref('PerformanceInsightsRetentionPeriod'), Ref('AWS::NoValue'))
+      PromotionTier FnJoin('', ['0', Ref(:ReaderPromotionTier)])
       Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader-instance' ])}]
     }
   end

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -83,10 +83,8 @@ CloudFormation do
   RDS_DBCluster(:DBCluster) {
     Engine external_parameters[:engine]
     EngineVersion engine_version unless engine_version.nil?
-    
     EngineMode(external_parameters[:engine_mode] == 'serverlessv2' ? 'provisioned' : external_parameters[:engine_mode])
     EnableLocalWriteForwarding FnIf('EnableLocalWriteForwarding', true, Ref('AWS::NoValue'))
-
     PreferredMaintenanceWindow maintenance_window unless maintenance_window.nil?
     
     if engine_mode == 'serverless' ||  engine_mode == 'serverlessv2'
@@ -105,6 +103,7 @@ CloudFormation do
     MasterUsername  FnIf('UseUsernameAndPassword', instance_username, Ref('AWS::NoValue'))
     MasterUserPassword  FnIf('UseUsernameAndPassword', instance_password, Ref('AWS::NoValue'))
     StorageEncrypted storage_encrypted
+    StorageType Ref(:StorageType)
     KmsKeyId Ref('KmsKeyId') if kms
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'cluster' ])}]
 

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -88,9 +88,9 @@ CloudFormation do
     EngineMode(external_parameters[:engine_mode] == 'serverlessv2' ? 'provisioned' : external_parameters[:engine_mode])
     EnableLocalWriteForwarding FnIf('EnableLocalWriteForwarding', true, Ref('AWS::NoValue'))
     PreferredMaintenanceWindow maintenance_window unless maintenance_window.nil?
-    
+    EnableHttpEndpoint Ref(:EnableHttpEndpoint)
+
     if engine_mode == 'serverless' ||  engine_mode == 'serverlessv2'
-      EnableHttpEndpoint Ref(:EnableHttpEndpoint)
       ServerlessV2ScalingConfiguration({
         MinCapacity: Ref('MinCapacity'),
         MaxCapacity: Ref('MaxCapacity')


### PR DESCRIPTION
- [Fixed `ServiceScalingTarget` for provisioned: values of `Number` type](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/810538030959b0b9d5ee761312e2971650b2875b)
- [Fixed ability to create ``reader`` instance](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/b003663f2a7b4d93579e58a267c0a55ede4644e2) (`reader` DNS host record as well) for `Serverless` with `EnableReader`
- [Allow set `StorageType` by `Ref` (i/o optimized is not by default)](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/34e59ce7a4c094f15668ceddb053f960f39321e1)
- [The `EnableReader` is common for both `provisioned` and `serverless`](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/814dc745217cdd33be8401fa3efadebe23497d08)
- [The `EnableHttpEndpoint` is common for both `provisioned` and `serverless`](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/c6598cb15d89683f66bbf7425a875daade75ec66)
- [Allow to set the `PromotionTier` parameter on a reader](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/daee882d2cb75c07173a8f9cf8627d974985c43e)
- [Allow set `DatabaseInsights` mode](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/513e53edf76617202953ec455a1c559b674e8409)
- [Set `Backtrack`](https://github.com/theonestack/hl-component-aurora-mysql/pull/40/commits/cf5fd759dc73cf732901ef6abeddce228a74e37a)