### PR TITLE
11 fixes (commits do not have conflicts)

### DIFF
--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -13,6 +13,7 @@ CfhighlanderTemplate do
     ComponentParam 'ScalableTargetMinCapacity'
     ComponentParam 'ScalableTargetMaxCapacity'
     ComponentParam 'EngineVersion'
+    ComponentParam 'StorageEncrypted', false
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -18,6 +18,7 @@ CfhighlanderTemplate do
     ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     ComponentParam 'EnableReader', 'false'
     ComponentParam 'ReaderPromotionTier', 1, allowedValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+    ComponentParam 'BacktrackWindow', 0
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -16,11 +16,12 @@ CfhighlanderTemplate do
     ComponentParam 'StorageEncrypted', false
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
+    ComponentParam 'EnableReader', 'false'
+    ComponentParam 'ReaderPromotionTier', 1, allowedValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
       ComponentParam 'ReaderInstanceType'
-      ComponentParam 'EnableReader', 'false'
     end
 
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -34,8 +34,8 @@ CfhighlanderTemplate do
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
 
     ComponentParam 'EnablePerformanceInsights', defined?(performance_insights) ? performance_insights : false
-    ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7
-
+    ComponentParam 'PerformanceInsightsRetentionPeriod', defined?(performance_insights) && defined?(insights_retention)  ? insights_retention.to_i : 7,
+                    allowedValues: [7, 31, 62, 93, 124, 155, 186, 217, 248, 279, 310, 341, 372, 403, 434, 465, 496, 527, 558, 589, 620, 651, 682, 713, 731]
     ComponentParam 'NamespaceId' if defined? service_discovery
 
     ComponentParam 'EnableReplicaAutoScaling', 'false'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -22,9 +22,9 @@ CfhighlanderTemplate do
       ComponentParam 'EnableReader', 'false'
     end
 
-    if engine_mode == 'serverless'
-      ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
-      ComponentParam 'MinCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
+    if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
+      ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
+      ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     end
 

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -12,6 +12,7 @@ CfhighlanderTemplate do
     ComponentParam 'SnapshotID'
     ComponentParam 'ScalableTargetMinCapacity'
     ComponentParam 'ScalableTargetMaxCapacity'
+    ComponentParam 'EngineVersion'
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -14,6 +14,7 @@ CfhighlanderTemplate do
     ComponentParam 'ScalableTargetMaxCapacity'
     ComponentParam 'EngineVersion'
     ComponentParam 'StorageEncrypted', false
+    ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'

--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -15,6 +15,7 @@ CfhighlanderTemplate do
     ComponentParam 'EngineVersion'
     ComponentParam 'StorageEncrypted', false
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
+    ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
 
     if engine_mode == 'provisioned'
       ComponentParam 'WriterInstanceType'
@@ -25,7 +26,6 @@ CfhighlanderTemplate do
     if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
       ComponentParam 'MaxCapacity', 2, allowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
       ComponentParam 'MinCapacity', 2, allowedValues: [0, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 192, 256]
-      ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     end
 
     ComponentParam 'KmsKeyId' if defined? kms_key_id

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -75,6 +75,7 @@ CloudFormation do
   engine_version = external_parameters.fetch(:engine_version, nil)
   engine_mode = external_parameters.fetch(:engine_mode, nil)
   maintenance_window = external_parameters.fetch(:maintenance_window, nil)
+  backtrack_window = external_parameters.fetch(:backtrack_window, nil)
 
   RDS_DBCluster(:DBCluster) {
     Engine external_parameters[:engine]
@@ -84,7 +85,11 @@ CloudFormation do
     EnableLocalWriteForwarding FnIf('EnableLocalWriteForwarding', true, Ref('AWS::NoValue'))
 
     PreferredMaintenanceWindow maintenance_window unless maintenance_window.nil?
-    
+    # Basically the same as `BacktrackWindow = 0`
+    if ((not backtrack_window.nil?) and (backtrack_window != 0))
+      BacktrackWindow backtrack_window
+    end
+
     if engine_mode == 'serverless'
       EnableHttpEndpoint Ref(:EnableHttpEndpoint)
       ServerlessV2ScalingConfiguration({

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -9,7 +9,6 @@ CloudFormation do
   Condition("EnablePerformanceInsights", FnEquals(Ref(:EnablePerformanceInsights), 'true'))
   Condition("EnableReplicaAutoScaling", FnAnd([FnEquals(Ref(:EnableReplicaAutoScaling), 'true'), FnEquals(Ref(:EnableReader), 'true')]))
   Condition("EnableCloudwatchLogsExports", FnNot(FnEquals(Ref(:EnableCloudwatchLogsExports), '')))
-
   Condition("EnableLocalWriteForwarding", FnEquals(Ref(:EnableLocalWriteForwarding), 'true'))
   
   tags = []
@@ -33,7 +32,6 @@ CloudFormation do
       Export FnSub("${EnvironmentName}-#{export}-Secret")
     }
   end
-
 
   security_group = external_parameters.fetch(:security_group, [])
   ip_blocks = external_parameters.fetch(:ip_blocks, [])
@@ -277,8 +275,8 @@ CloudFormation do
   ApplicationAutoScaling_ScalableTarget(:ServiceScalingTarget) do
     DependsOn 'RDSReplicaAutoScaleRole'
     Condition 'EnableReplicaAutoScaling'
-    MaxCapacity Ref(:ScalableTargetMaxCapacity)
-    MinCapacity Ref(:ScalableTargetMinCapacity)
+    MaxCapacity FnJoin('', ['0', Ref(:ScalableTargetMaxCapacity)])
+    MinCapacity FnJoin('', ['0', Ref(:ScalableTargetMinCapacity)])
     ResourceId FnJoin(':',["cluster",Ref(:DBCluster)])
     RoleARN FnGetAtt(:RDSReplicaAutoScaleRole,:Arn)
     ScalableDimension "rds:cluster:ReadReplicaCount"

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -108,6 +108,7 @@ CloudFormation do
     MasterUsername  FnIf('UseUsernameAndPassword', instance_username, Ref('AWS::NoValue'))
     MasterUserPassword  FnIf('UseUsernameAndPassword', instance_password, Ref('AWS::NoValue'))
     StorageEncrypted storage_encrypted
+    StorageType Ref(:StorageType)
     KmsKeyId Ref('KmsKeyId') if kms
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'cluster' ])}]
 

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -89,9 +89,9 @@ CloudFormation do
     if ((not backtrack_window.nil?) and (backtrack_window != 0))
       BacktrackWindow backtrack_window
     end
+    EnableHttpEndpoint Ref(:EnableHttpEndpoint)
 
     if engine_mode == 'serverless' ||  engine_mode == 'serverlessv2'
-      EnableHttpEndpoint Ref(:EnableHttpEndpoint)
       ServerlessV2ScalingConfiguration({
         MinCapacity: Ref('MinCapacity'),
         MaxCapacity: Ref('MaxCapacity')

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -119,7 +119,6 @@ CloudFormation do
         EnableCloudwatchLogsExports FnIf('EnableCloudwatchLogsExports', FnSplit(',',external_parameters[:log_exports]), Ref('AWS::NoValue'))
       end
     end
-    
   }
 
   if engine_mode == 'serverless' || engine_mode == 'serverlessv2'
@@ -127,6 +126,8 @@ CloudFormation do
       Engine external_parameters[:engine]
       DBInstanceClass 'db.serverless'
       DBClusterIdentifier Ref(:DBCluster)
+      EnablePerformanceInsights Ref('EnablePerformanceInsights')
+      PerformanceInsightsRetentionPeriod FnIf('EnablePerformanceInsights', Ref('PerformanceInsightsRetentionPeriod'), Ref('AWS::NoValue'))
       Tags tags
     }
 
@@ -135,6 +136,8 @@ CloudFormation do
       Engine external_parameters[:engine]
       DBInstanceClass 'db.serverless'
       DBClusterIdentifier Ref(:DBCluster)
+      EnablePerformanceInsights Ref('EnablePerformanceInsights')
+      PerformanceInsightsRetentionPeriod FnIf('EnablePerformanceInsights', Ref('PerformanceInsightsRetentionPeriod'), Ref('AWS::NoValue'))
       PromotionTier FnJoin('', ['0', Ref(:ReaderPromotionTier)])
       Tags tags
     }

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -90,7 +90,7 @@ CloudFormation do
       BacktrackWindow backtrack_window
     end
 
-    if engine_mode == 'serverless'
+    if engine_mode == 'serverless' ||  engine_mode == 'serverlessv2'
       EnableHttpEndpoint Ref(:EnableHttpEndpoint)
       ServerlessV2ScalingConfiguration({
         MinCapacity: Ref('MinCapacity'),
@@ -98,13 +98,6 @@ CloudFormation do
       })
     end
 
-    if engine_mode == 'serverlessv2'
-      EnableHttpEndpoint Ref(:EnableHttpEndpoint)
-      ServerlessV2ScalingConfiguration({
-        MinCapacity: Ref('MinCapacity'),
-        MaxCapacity: Ref('MaxCapacity')
-      })
-    end
     DatabaseName db_name if !db_name.empty?
     DBClusterParameterGroupName Ref(:DBClusterParameterGroup)
     SnapshotIdentifier FnIf('UseSnapshotID',Ref(:SnapshotID), Ref('AWS::NoValue'))


### PR DESCRIPTION
- [The `Ref` makes a `String`. The lead zero does the trick: `CloudFormation` parses it as a `Number`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/aca95ae66b348580ce99f245549a17b829695177)
- [Fixed `EngineVersion` parameter: it can be defined with `Ref` in `external_parameters`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/b5938cddb7f1cec2694e49b088c8a1f2c38a897d)
- [Fixed `StorageEncrypted` parameter: it can be defined with `Ref` in `external_parameters`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/404ebbcd7ad60f467f5ee308a3a37d7965a52505)
- [Allow set `StorageType` with `Ref` separately for each cluster: standar or I/O-optimized.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/def5e8f44baf42b8a880317fb021d96cf5ba7705)
- [Allow set `Backtrack` with `external_parameters`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/b71b024c86ed6960c09d85510977e4d6e950ccd9)
- [Some fixes of `capacities` for `Serverless`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/a722484788f655aa138048efb2af210036838bad)
- [Make the `EnableHttpEndpoint` common for both `provisioned` and `serverless` ](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/d463c054bc3bed59c60aed5a62d2f136a96e0d85)
- [Make the `EnableReader` common for both `provisioned` and `serverless`. Allow to set instance `ProvisionTier` to control scaling behavior.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/a57b071a3b24d421e7b30a24887cd7f0b6784ea4)
- [Allow `Performance Insights` for `serverless` on instance-level.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/d21f95d39c3d3c64474864b23d16b8042fa0e8f6)
- [Fixed `DBParameterGroupName` for `serverless` same as for `provisioned`.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/b78484af1b11163cbc42ece292371c81c0defd65)
- [Allow to set `BacktrackWindow` via environment repository.](https://github.com/theonestack/hl-component-aurora-mysql/pull/42/commits/a3527c9ed5879184b57c76529fdcadc7ff8a9b08)