### PR TITLE
feature/reader-dbi-parameter-group

### DIFF
--- a/aurora-mysql.cfhighlander.rb
+++ b/aurora-mysql.cfhighlander.rb
@@ -17,6 +17,7 @@ CfhighlanderTemplate do
     ComponentParam 'StorageType', 'aurora', allowedValues: ['aurora', 'aurora-iopt1']
     ComponentParam 'EnableHttpEndpoint', 'false', allowedValues: ['true', 'false']
     ComponentParam 'EnableReader', 'false'
+    ComponentParam 'ReaderOwnParameterGroup', 'false'
     ComponentParam 'ReaderPromotionTier', 1, allowedValues: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
     ComponentParam 'BacktrackWindow', 0
 

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -13,7 +13,6 @@ CloudFormation do
   Condition("EnableReader", FnEquals(Ref(:EnableReader), 'true'))
   Condition("EnableReaderOwnParameterGroup", FnEquals(Ref(:ReaderOwnParameterGroup), 'true'))
   
-  
   Condition("IsWriterServerless", FnEquals(Ref(:WriterInstanceType), 'db.serverless'))
   Output('IsWriterServerless') { 
     Value( FnIf(:IsWriterServerless, true, false) ) 
@@ -102,9 +101,9 @@ CloudFormation do
     Condition(:EnableReaderOwnParameterGroup)
     Description FnJoin(' ', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader instance parameter group' ])
     Family external_parameters[:family]
-    Parameters external_parameters[:reader_instance_parameters]
+    Parameters external_parameters.fetch([:reader_instance_parameters],[:instance_parameters])
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader-instance-parameter-group' ])}]
-  }
+  }  
 
   RDS_DBCluster(:DBCluster) {
     Engine external_parameters[:engine]
@@ -161,7 +160,7 @@ CloudFormation do
     RDS_DBInstance(:ServerlessDBInstanceReader) {
       Condition(:EnableReader)
       DBSubnetGroupName Ref(:DBClusterSubnetGroup)
-      DBParameterGroupName Fnif(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
+      DBParameterGroupName FnIf(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
       Engine external_parameters[:engine]
       DBClusterIdentifier Ref(:DBCluster)
       AutoMinorVersionUpgrade minor_upgrade unless minor_upgrade.nil?
@@ -189,7 +188,7 @@ CloudFormation do
     RDS_DBInstance(:DBClusterInstanceReader) {
       Condition(:EnableReader)
       DBSubnetGroupName Ref(:DBClusterSubnetGroup)
-      DBParameterGroupName Fnif(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
+      DBParameterGroupName FnIf(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
       Engine external_parameters[:engine]
       DBClusterIdentifier Ref(:DBCluster)
       AutoMinorVersionUpgrade minor_upgrade unless minor_upgrade.nil? 

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -11,7 +11,7 @@ CloudFormation do
   Condition("EnableCloudwatchLogsExports", FnNot(FnEquals(Ref(:EnableCloudwatchLogsExports), '')))
   Condition("EnableLocalWriteForwarding", FnEquals(Ref(:EnableLocalWriteForwarding), 'true'))
   Condition("EnableReader", FnEquals(Ref(:EnableReader), 'true'))
-  Condition("EnableReaderOwnParameterGroup", FnEquals(Ref(:ReaderOwnParameterGroup), 'true'))
+  Condition("EnableReaderOwnParameterGroup", FnAnd([FnEquals(Ref(:ReaderOwnParameterGroup), 'true'), FnEquals(Ref(:EnableReader), 'true')]))
   
   Condition("IsWriterServerless", FnEquals(Ref(:WriterInstanceType), 'db.serverless'))
   Output('IsWriterServerless') { 
@@ -93,7 +93,7 @@ CloudFormation do
   RDS_DBParameterGroup(:DBInstanceParameterGroup) {
     Description FnJoin(' ', [ Ref(:EnvironmentName), external_parameters[:component_name], 'instance parameter group' ])
     Family external_parameters[:family]
-    Parameters external_parameters[:instance_parameters]
+    Parameters external_parameters.fetch(:instance_parameters, {})
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'instance-parameter-group' ])}]
   }
 
@@ -101,7 +101,7 @@ CloudFormation do
     Condition(:EnableReaderOwnParameterGroup)
     Description FnJoin(' ', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader instance parameter group' ])
     Family external_parameters[:family]
-    Parameters external_parameters.fetch([:reader_instance_parameters],[:instance_parameters])
+    Parameters external_parameters.fetch(:reader_instance_parameters, {})
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader-instance-parameter-group' ])}]
   }  
 

--- a/aurora-mysql.cfndsl.rb
+++ b/aurora-mysql.cfndsl.rb
@@ -11,6 +11,8 @@ CloudFormation do
   Condition("EnableCloudwatchLogsExports", FnNot(FnEquals(Ref(:EnableCloudwatchLogsExports), '')))
   Condition("EnableLocalWriteForwarding", FnEquals(Ref(:EnableLocalWriteForwarding), 'true'))
   Condition("EnableReader", FnEquals(Ref(:EnableReader), 'true'))
+  Condition("EnableReaderOwnParameterGroup", FnEquals(Ref(:ReaderOwnParameterGroup), 'true'))
+  
   
   Condition("IsWriterServerless", FnEquals(Ref(:WriterInstanceType), 'db.serverless'))
   Output('IsWriterServerless') { 
@@ -96,7 +98,13 @@ CloudFormation do
     Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'instance-parameter-group' ])}]
   }
 
-  
+  RDS_DBParameterGroup(:DBReaderInstanceParameterGroup) {
+    Condition(:EnableReaderOwnParameterGroup)
+    Description FnJoin(' ', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader instance parameter group' ])
+    Family external_parameters[:family]
+    Parameters external_parameters[:reader_instance_parameters]
+    Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), external_parameters[:component_name], 'reader-instance-parameter-group' ])}]
+  }
 
   RDS_DBCluster(:DBCluster) {
     Engine external_parameters[:engine]
@@ -153,7 +161,7 @@ CloudFormation do
     RDS_DBInstance(:ServerlessDBInstanceReader) {
       Condition(:EnableReader)
       DBSubnetGroupName Ref(:DBClusterSubnetGroup)
-      DBParameterGroupName Ref(:DBInstanceParameterGroup)
+      DBParameterGroupName Fnif(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
       Engine external_parameters[:engine]
       DBClusterIdentifier Ref(:DBCluster)
       AutoMinorVersionUpgrade minor_upgrade unless minor_upgrade.nil?
@@ -181,7 +189,7 @@ CloudFormation do
     RDS_DBInstance(:DBClusterInstanceReader) {
       Condition(:EnableReader)
       DBSubnetGroupName Ref(:DBClusterSubnetGroup)
-      DBParameterGroupName Ref(:DBInstanceParameterGroup)
+      DBParameterGroupName Fnif(:EnableReaderOwnParameterGroup, Ref(:DBReaderInstanceParameterGroup), Ref(:DBInstanceParameterGroup))
       Engine external_parameters[:engine]
       DBClusterIdentifier Ref(:DBCluster)
       AutoMinorVersionUpgrade minor_upgrade unless minor_upgrade.nil? 


### PR DESCRIPTION
Allow to define a separate parameter instance group for reader replicas with stack-level config like next:
```yaml
cfVersion: dev-e66e9a7
EnvironmentName: qa5
EnvironmentType: development
RegionCode: eu
DBName: loyverse
WriterInstanceType: db.t4g.medium
ReaderInstanceType: db.t4g.medium
EnablePerformanceInsights: 'false'
MaxConnections: '341'
EnableReader: 'true'
EngineVersion: 8.0.mysql_aurora.3.09.0
ReaderOwnParameterGroup: 'true'
```